### PR TITLE
Update bulletin fetching to use local JSON file instead of API endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
             });
         }
 
-        fetch('/api/bulletins')
+        fetch('data/bulletins.json')
             .then(response => response.json())
             .then(data => {
                 const bulletins = data.map(b => parseBulletinFilename(b.name)).filter(Boolean);


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Fetch bulletins from data/bulletins.json instead of the API